### PR TITLE
FIX kmeans_dpcpp path in pythonpath for ci test pipeline

### DIFF
--- a/.github/workflows/test_cpu_benchmarks.yaml
+++ b/.github/workflows/test_cpu_benchmarks.yaml
@@ -140,4 +140,4 @@ jobs:
     - name: Run k-means benchmarks
       run: |
         cd benchmarks/kmeans
-        PYTHONPATH=$PYTHONPATH:$(realpath ./kmeans_dpcpp/) benchopt run --no-plot -l -d Simulated_correlated_data[n_samples=1000,n_features=14]
+        PYTHONPATH=$PYTHONPATH:$(realpath ../../kmeans_dpcpp/) benchopt run --no-plot -l -d Simulated_correlated_data[n_samples=1000,n_features=14]


### PR DESCRIPTION
Fixes https://github.com/soda-inria/sklearn-engine-benchmarks/issues/4